### PR TITLE
Implement 2FA with TOTP

### DIFF
--- a/syncclient/schema.go
+++ b/syncclient/schema.go
@@ -7,12 +7,22 @@ type loginRequestSchema struct {
 }
 
 type loginResponseSchema struct {
-	UserID         string `json:"uid"`
-	SessionToken   string `json:"sessionToken"`
-	AuthAt         int64  `json:"authAt"`
-	MetricsEnabled bool   `json:"metricsEnabled"`
-	KeyFetchToken  string `json:"keyFetchToken"`
-	Verified       bool   `json:"verified"`
+	UserID             string `json:"uid"`
+	SessionToken       string `json:"sessionToken"`
+	AuthAt             int64  `json:"authAt"`
+	MetricsEnabled     bool   `json:"metricsEnabled"`
+	KeyFetchToken      string `json:"keyFetchToken"`
+	Verified           bool   `json:"verified"`
+	VerificationMethod string `json:"verificationMethod"`
+}
+
+type totpVerifyRequestSchema struct {
+	Code    string `json:"code"`
+	Service string `json:"service"`
+}
+
+type totpVerifyResponseSchema struct {
+	Success bool `json:"success"`
 }
 
 type keysResponseSchema struct {


### PR DESCRIPTION
Hi, thanks for the useful tool!

I recently enabled 2FA on my Firefox account, using TOTP codes.
This breaks the ffsyncclient login process with a _You must verify the login attempt_ message, which might be fine when the verification can be performed out-of-band (email), but it's a blocker for TOTP.

This PR adds an optional step (1b) during login. If a second factor of type _totp-2fa_ is required by the server, ffsyncclient will ask the user for an OTP and call the required verification endpoint.